### PR TITLE
Save button bug fixes

### DIFF
--- a/inst/htmlwidgets/glimmaXY.js
+++ b/inst/htmlwidgets/glimmaXY.js
@@ -74,7 +74,6 @@ HTMLWidgets.widget({
         };
 
         setupXYInteraction(data);
-        addSavePlotButton(controlContainer, xyView, expressionView, "Save Plot");
         if (expressionView) {
           addAxisMessage(data);
         }
@@ -194,8 +193,19 @@ function setupXYInteraction(data)
                     },
                     { 
                       text: 'Save Data',
-                      action: () => showDataDropdown(),
+                      action: () => {
+                        let dropdown = document.getElementsByClassName("dataDropdown")[0];
+                        dropdown.classList.toggle("show");
+                      },
                       attr: {class: 'save-button saveSubset'}
+                    },
+                    {
+                      text: 'Save Plot',
+                      action: () => {
+                        let dropdown = document.getElementsByClassName("plotDropdown")[0];
+                        dropdown.classList.toggle("show");
+                      },
+                      attr: {class: 'save-button savePlot'}
                     }
                   ]
                 },
@@ -208,17 +218,10 @@ function setupXYInteraction(data)
     datatable.on('click', 'tr', function() { tableClickListener(datatable, state, data, $(this)) } );
     data.xyView.addSignalListener('click', function(name, value) { XYSignalListener(datatable, state, value[0], data) } );
 
-    $(document.getElementsByClassName("saveSubset")[0]).html(`Save Data`);
     addSaveDataElement(state, data, `Save All`, `Save (0)`);
+    addSavePlotElement(data.xyView, data.expressionView);
+    hideDropdownsOnHoverAway();
   });
-}
-
-/**
- * Shows Save Data options
- */
-function showDataDropdown() {
-  let dataDropdown = document.getElementsByClassName("dataDropdown")[0];
-  dropdownOnClick(dataDropdown);
 }
 
 /**

--- a/inst/htmlwidgets/lib/GlimmaV2/saveTools.js
+++ b/inst/htmlwidgets/lib/GlimmaV2/saveTools.js
@@ -1,16 +1,14 @@
 function hideDropdownsOnHoverAway() 
 {
-  // set up dropdown hide when clicking elsewhere
-  window.addEventListener("click", (event) => {
-    if (!event.target.matches(".save-button")
-      && !event.target.parentElement.matches(".save-button")      
-    ) {
-      var dropdownContents = document.getElementsByClassName("dropdown-content");
-      for (const dropdownContent of dropdownContents) {
-        if (dropdownContent.classList.contains("show")) {
-          dropdownContent.classList.remove("show");
-        }
-      }
+  window.addEventListener("mouseover", (event) => {
+    console.log(event.target);
+    const buttonContainer = event.target.closest(".buttonContainer");
+    if (buttonContainer !== null) {
+      return;
+    }
+    var dropdownContents = document.getElementsByClassName("dropdown-content");
+    for (const dropdownContent of dropdownContents) {
+      dropdownContent.classList.remove("show");
     }
   });
 }

--- a/inst/htmlwidgets/lib/GlimmaV2/saveTools.js
+++ b/inst/htmlwidgets/lib/GlimmaV2/saveTools.js
@@ -1,96 +1,62 @@
-function addSavePlotButton(controlContainer, xy_obj, exp_obj=null, 
-  text="Save Plot", summaryText="Summary plot", expressionText="Expression plot") 
+function hideDropdownsOnHoverAway() 
 {
-  // set up button elements
-  var dropdownDiv = document.createElement("div");
-  dropdownDiv.setAttribute("class", "dropdown");
-
-  var dropdownButton = document.createElement("button");
-  dropdownButton.setAttribute("class", "save-button");
-  dropdownButton.innerHTML = text;
-
-  var dropdownContent = document.createElement("div");
-  dropdownContent.setAttribute("class", "dropdown-content");
-  
-  var pngSummaryBtn = addSaveButtonElement(xy_obj, text=summaryText+" (PNG)", type='png');
-  var svgSummaryBtn = addSaveButtonElement(xy_obj, text=summaryText+" (SVG)", type='svg');
-  
-  // add elements to container
-  dropdownDiv.appendChild(dropdownButton);
-  dropdownDiv.appendChild(dropdownContent);
-
-  dropdownContent.appendChild(pngSummaryBtn);
-  dropdownContent.appendChild(svgSummaryBtn);
-
-  // add the expression buttons if expression plot is active
-  if (exp_obj) {
-    var pngExpressionBtn = addSaveButtonElement(exp_obj, text=expressionText+" (PNG)", type='png');
-    var svgExpressionBtn = addSaveButtonElement(exp_obj, text=expressionText+" (SVG)", type='svg');
-  
-    dropdownContent.appendChild(pngExpressionBtn);
-    dropdownContent.appendChild(svgExpressionBtn);
-  }
-
-  // set up dropdown action
-  dropdownButton.onclick = function() {
-    dropdownOnClick(dropdownContent);
-  };
-
-  controlContainer.appendChild(dropdownDiv);
-
   // set up dropdown hide when clicking elsewhere
-  // global window.dropdownHide so this event is only added once
-  if (!window.dropdownHide) {
-    function hideDropdowns(event) {
-      if (!event.target.matches(".save-button")) {
-        var dropdowns = document.getElementsByClassName("dropdown-content");
-
-        for (const dropdown_i of dropdowns) {
-          if (dropdown_i.classList.contains("show")) {
-            dropdown_i.classList.remove("show");
-          }
+  window.addEventListener("click", (event) => {
+    if (!event.target.matches(".save-button")
+      && !event.target.parentElement.matches(".save-button")      
+    ) {
+      var dropdownContents = document.getElementsByClassName("dropdown-content");
+      for (const dropdownContent of dropdownContents) {
+        if (dropdownContent.classList.contains("show")) {
+          dropdownContent.classList.remove("show");
         }
       }
     }
+  });
+}
 
-    window.addEventListener("click", hideDropdowns);
+// creates the save plot button
+function addSavePlotElement(xyPlot, expressionPlot=null) {
+  let buttonContainer = document.getElementsByClassName("savePlot")[0].parentElement;
 
-    window.dropdownHide = true;
+  var dropdown = document.createElement("div");
+  dropdown.setAttribute("class", "dropdown-content plotDropdown");
+
+  // add elements to container
+  const createSavePlotButton = (plot, text, type) => {
+    var saveButton = document.createElement("a");
+    saveButton.setAttribute("href", "#");
+    saveButton.innerText = text;
+    saveButton.onclick = function() {
+      plot.toImageURL(type, scaleFactor=3).then(function (url) {
+        var link = document.createElement('a');
+        link.setAttribute('href', url);
+        link.setAttribute('target', '_blank');
+        link.setAttribute('download', 'vega-export.' + type);
+        link.dispatchEvent(new MouseEvent('click'));
+      });
+    };
+    return saveButton;
   }
-}
+  var pngSummaryBtn = createSavePlotButton(xyPlot, text="Summary plot (PNG)", type='png');
+  var svgSummaryBtn = createSavePlotButton(xyPlot, text="Summary plot (SVG)", type='svg');
+  dropdown.appendChild(pngSummaryBtn);
+  dropdown.appendChild(svgSummaryBtn);
 
-function dropdownOnClick(dropdownContent) {
-  var dropdowns = document.getElementsByClassName("dropdown-content");
-  for (const dropdown_i of dropdowns){
-    if (dropdown_i.classList.contains("show")) {
-      dropdown_i.classList.remove("show");
-    }
+  // add the expression buttons if expression plot is active
+  if (expressionPlot) {
+    var pngExpressionBtn = createSavePlotButton(expressionPlot, text="Expression plot (PNG)", type='png');
+    var svgExpressionBtn = createSavePlotButton(expressionPlot, text="Expression plot (SVG)", type='svg');
+    dropdown.appendChild(pngExpressionBtn);
+    dropdown.appendChild(svgExpressionBtn);
   }
-  dropdownContent.classList.toggle("show");
-}
 
-function addSaveButtonElement(view_obj, text, type) {
-  // create a save button element for the save dropdown
-  var saveButton = document.createElement("a");
-  saveButton.setAttribute("href", "#");
-  saveButton.innerText = text;
-  saveButton.onclick = function() {
-    view_obj.toImageURL(type, scaleFactor=3).then(function (url) {
-      var link = document.createElement('a');
-      link.setAttribute('href', url);
-      link.setAttribute('target', '_blank');
-      link.setAttribute('download', 'vega-export.' + type);
-      link.dispatchEvent(new MouseEvent('click'));
-    });
-  };
-  return saveButton;
-}
+  buttonContainer.appendChild(dropdown);
+} 
 
+// creates the save data button
 function addSaveDataElement(state, data, saveAllText, saveSelectText) {
   buttonContainer = document.getElementsByClassName("saveSubset")[0].parentElement;
-
-  var dropdownDiv = document.createElement("div");
-  dropdownDiv.setAttribute("class", "dropdown");
 
   var dropdownContent = document.createElement("div");
   dropdownContent.setAttribute("class", "dropdown-content dataDropdown");

--- a/inst/htmlwidgets/lib/vega/vega_plots.css
+++ b/inst/htmlwidgets/lib/vega/vega_plots.css
@@ -96,6 +96,7 @@
 /* Datatables button container styling */
 .buttonContainer {
 	display: inline-block;
+	margin: 0px 5px 0px 0px;
 }
 
 button.save-button {


### PR DESCRIPTION
## Before 🚨

https://github.com/user-attachments/assets/f80c2247-72b3-4dba-9243-ba1a6ba6a943

- `Save Plot` button is at the bottom of the widget which not only looks clunky but also increases the size of the widget dynamically, which is unexpected and may affect the formatting of reports
- Dropdowns fade when you click away from them

# After

https://github.com/user-attachments/assets/0be1a854-ff41-4343-892f-5201e5c5ce33

- `Save Plot` button is moved near the `Save Data` button, meaning it no longer changes the size of the widget
- Dropdowns fade when hovering the mouse away from them - feels more natural 🎉

# Testing
Export summary PNG ✅
Export summary SVG ✅
Export expression PNG ✅
Export expression SVG ✅
Export data ✅