### PR TITLE
[MDS] Remove scrollbar in Quarto documents

### DIFF
--- a/inst/htmlwidgets/glimmaMDS.js
+++ b/inst/htmlwidgets/glimmaMDS.js
@@ -9,9 +9,7 @@ const CLASSNAMES = {
   dimmedBox: "dimmedBox",
   saveModal: "saveModal",
   show: "show",
-  alertBox: "alertBox",
-  invisible: "invisible",
-  warning: "warning",
+  warningBox: "warningBox",
 };
 
 HTMLWidgets.widget({
@@ -79,8 +77,8 @@ HTMLWidgets.widget({
 
         eigenView.runAsync();
         linkPlotsMDS(mdsView, eigenView);
+        addSavePlotButton(controlContainer, mdsView, eigenView);
         addColourMessage(x.data, mdsView, controlContainer);
-        addSavePlotButton(widget, controlContainer, mdsView, eigenView);
       },
 
       resize: function(_, _)
@@ -90,12 +88,12 @@ HTMLWidgets.widget({
   }
 });
 
-function addSavePlotButton(widget, controlContainer, mdsPlot, eigenPlot) 
+function addSavePlotButton(controlContainer, mdsPlot, eigenPlot) 
 {
   const saveContainer = document.createElement("div");
   saveContainer.setAttribute("class", CLASSNAMES.saveContainer);
 
-  widget.insertBefore(saveContainer, controlContainer);
+  controlContainer.appendChild(saveContainer);
 
   const button = document.createElement("button");
   button.setAttribute("class", CLASSNAMES.saveButton);
@@ -188,9 +186,8 @@ function linkPlotsMDS(mdsView, eigenView)
 
 function addColourMessage(data, view, container)
 {
-  var alertBox = document.createElement("div");
-  alertBox.classList.add(CLASSNAMES.alertBox);
-  alertBox.classList.add(CLASSNAMES.invisible);
+  const warningBox = document.createElement("div");
+  warningBox.classList.add(CLASSNAMES.warningBox);
   // update the warning box when colourscheme signal changes
   view.addSignalListener('colourscheme',
     (_, value) => updateColourMessage(data, container, view, value));
@@ -198,25 +195,23 @@ function addColourMessage(data, view, container)
   view.addSignalListener('colour_by',
     (_, value) => updateColourMessage(data, container, view, view.signal('colourscheme'))
   );
-  container.appendChild(alertBox);
+  container.appendChild(warningBox);
 }
 
 function updateColourMessage(data, container, view, value)
 {
-  var alertBox = container.getElementsByClassName(CLASSNAMES.alertBox)[0];
+  const warningBox = container.getElementsByClassName(CLASSNAMES.warningBox)[0];
   let schemeCount = vega.scheme(value).length;
   let colourBy = view.signal("colour_by");
   let colourCount = [...new Set(data.mdsData[colourBy])].length;
-  alertBox.classList.remove(CLASSNAMES.warning);
-  alertBox.classList.add(CLASSNAMES.invisible);
+  warningBox.classList.remove(CLASSNAMES.show);
 
   if (data.continuousColour) return;
   if (value === "plasma" || value === "viridis") return;
   if (colourBy === "-") return;
 
   if (schemeCount < colourCount) {
-    alertBox.innerHTML = `Warning: not enough distinct colours. ${schemeCount} supported.`;
-    alertBox.classList.remove(CLASSNAMES.invisible);
-    alertBox.classList.add(CLASSNAMES.warning);
+    warningBox.innerHTML = `Warning: not enough distinct colours. ${schemeCount} supported.`;
+    warningBox.classList.add(CLASSNAMES.show);
   }
 }

--- a/inst/htmlwidgets/lib/libMDS/styles.css
+++ b/inst/htmlwidgets/lib/libMDS/styles.css
@@ -14,40 +14,27 @@
 }
 
 .saveContainer {
-	text-align: end;
-	margin: 0px 20px;
+	margin-top: 10px;
+	margin-left: 15px;
 }
 
 .controlContainer {
 	padding: 10px;
 	display: grid;
-	grid-template-columns: repeat(6, 1fr);
+	grid-template-columns: repeat(7, 1fr);
 	font-family: sans-serif;
 	color: #353535;
 	font-size: 9px;
 }
 
 button.saveButton {
-    box-sizing: border-box;
-    padding: 0.3em 0.5em;
-    font-size: 9pt;
+    padding: 3px;
     border: 1px solid #e7e7e7;
     border-radius: 3px;
     cursor: pointer;
-    line-height: 1.6em;
-    color: black;
-    white-space: nowrap;
-    overflow: hidden;
     background-color: #e7e7e7;
-    background-image: none;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
-    user-select: none;
-    text-decoration: none;
     outline: none;
-    text-overflow: ellipsis;
 }
 
 button.saveButton:hover 
@@ -106,31 +93,18 @@ button.saveButton:active {
 	display: block;
 }
 
-.alertBox 
+.warningBox 
 {
+	display: none;
 	text-align: center;
 	font-family: sans-serif;
 	padding: 2px;
 	margin: 10px;
 	font-size: 10pt;
-	color: #383d41;
-	background-color: #e2e3e5;
-	border: 1px solid #d6d8db;
-	border-radius: .25rem;
-}
-
-.invisible 
-{
-	display: none;
-}
-
-.warning
-{
-	display: inline-block;
-	margin-left: 0px;
 	color: #721c24;
 	background-color: #f8d7da;
 	border: 1px solid #f5c6cb;
+	border-radius: .25rem;
 }
 
 /* styling vega components */


### PR DESCRIPTION
# PR Description

By moving the save modal into the `controlContainer`, we can eliminate the scrollbar in the knitted Quarto document and make the plots appear flush with the rest of the document

## Before
<img width="400" alt="Screenshot 2025-01-13 at 2 15 25 pm" src="https://github.com/user-attachments/assets/768427e4-a86a-49c6-acdf-d3969e9467b4" />

<img width="400" alt="Screenshot 2025-01-13 at 2 15 34 pm" src="https://github.com/user-attachments/assets/ed7efdda-cc98-4c91-9df6-d5237b37a4ab" />

## After
<img width="400" alt="Screenshot 2025-01-13 at 2 09 56 pm" src="https://github.com/user-attachments/assets/39547282-dfa9-4504-be3c-9306646c7527" />
<img width="400" alt="Screenshot 2025-01-13 at 2 10 01 pm" src="https://github.com/user-attachments/assets/9ccfe450-43a1-4888-9239-fcecc9944044" />
