### PR TITLE
[XY] Performance + UI improvements

### DIFF
--- a/inst/htmlwidgets/glimmaMDS.yaml
+++ b/inst/htmlwidgets/glimmaMDS.yaml
@@ -4,6 +4,8 @@ dependencies:
     src: htmlwidgets/lib/vega
     script:
       - vega.min.js
+    stylesheet:
+      - vega-styles.css
   - name: vega-tooltip
     version: 1.0
     src: htmlwidgets/lib/vega-tooltip

--- a/inst/htmlwidgets/glimmaXY.js
+++ b/inst/htmlwidgets/glimmaXY.js
@@ -31,7 +31,7 @@ HTMLWidgets.widget({
         var xyTable = HTMLWidgets.dataframeToD3(x.data.table)
         var xySpec = createXYSpec(x.data, xyTable, width, height);
         var xyView = new vega.View(vega.parse(xySpec), {
-          renderer: 'svg',
+          renderer: 'canvas',
           container: xyContainer,
           bind: controlContainer,
           hover: true
@@ -51,7 +51,7 @@ HTMLWidgets.widget({
           countsMatrix = HTMLWidgets.dataframeToD3(x.data.counts);
           var expressionSpec = createExpressionSpec(width, height, x.data.expCols, x.data.sampleColours, x.data.samples);
           var expressionView = new vega.View(vega.parse(expressionSpec), {
-            renderer: 'svg',
+            renderer: 'canvas',
             container: expressionContainer,
             hover: true
           });

--- a/inst/htmlwidgets/glimmaXY.js
+++ b/inst/htmlwidgets/glimmaXY.js
@@ -46,13 +46,20 @@ HTMLWidgets.widget({
         {
           expressionContainer = document.createElement("div");
           expressionContainer.setAttribute("class", "expressionContainer");
+
           plotContainer.appendChild(expressionContainer);
           xyContainer.setAttribute("class", "xyContainer");
+
+          const expressionControls = document.createElement("div");
+          expressionControls.setAttribute("class", "expressionControls");
+          plotContainer.appendChild(expressionControls);
+
           countsMatrix = HTMLWidgets.dataframeToD3(x.data.counts);
           var expressionSpec = createExpressionSpec(width, height, x.data.expCols, x.data.sampleColours, x.data.samples);
           var expressionView = new vega.View(vega.parse(expressionSpec), {
             renderer: 'canvas',
             container: expressionContainer,
+            bind: expressionControls,
             hover: true
           });
           expressionView.tooltip(handler.call);
@@ -210,6 +217,7 @@ function setupXYInteraction(data)
                   ]
                 },
         scrollY: (data.height*0.4).toString() + "px",
+        scroller: true,
         scrollX: false,
         orderClasses: false,
         stripeClasses: ['stripe1','stripe2']

--- a/inst/htmlwidgets/glimmaXY.js
+++ b/inst/htmlwidgets/glimmaXY.js
@@ -50,15 +50,19 @@ HTMLWidgets.widget({
           plotContainer.appendChild(expressionContainer);
           xyContainer.setAttribute("class", "xyContainer");
 
+          const expressionPlotContainer = document.createElement("div");
+          expressionPlotContainer.setAttribute("class", "expressionPlotContainer");
+          expressionContainer.appendChild(expressionPlotContainer);
+
           const expressionControls = document.createElement("div");
           expressionControls.setAttribute("class", "expressionControls");
-          plotContainer.appendChild(expressionControls);
+          expressionContainer.appendChild(expressionControls);
 
           countsMatrix = HTMLWidgets.dataframeToD3(x.data.counts);
           var expressionSpec = createExpressionSpec(width, height, x.data.expCols, x.data.sampleColours, x.data.samples);
           var expressionView = new vega.View(vega.parse(expressionSpec), {
             renderer: 'canvas',
-            container: expressionContainer,
+            container: expressionPlotContainer,
             bind: expressionControls,
             hover: true
           });
@@ -216,7 +220,7 @@ function setupXYInteraction(data)
                     }
                   ]
                 },
-        scrollY: (data.height*0.35).toString() + "px",
+        scrollY: (data.height*0.33).toString() + "px",
         scroller: true,
         scrollX: false,
         orderClasses: false,

--- a/inst/htmlwidgets/glimmaXY.js
+++ b/inst/htmlwidgets/glimmaXY.js
@@ -216,11 +216,11 @@ function setupXYInteraction(data)
                     }
                   ]
                 },
-        scrollY: (data.height*0.4).toString() + "px",
+        scrollY: (data.height*0.35).toString() + "px",
         scroller: true,
         scrollX: false,
         orderClasses: false,
-        stripeClasses: ['stripe1','stripe2']
+        stripeClasses: ['stripe1','stripe2'],
       });
 
     datatable.on('click', 'tr', function() { tableClickListener(datatable, state, data, $(this)) } );

--- a/inst/htmlwidgets/glimmaXY.yaml
+++ b/inst/htmlwidgets/glimmaXY.yaml
@@ -16,6 +16,8 @@ dependencies:
     src: htmlwidgets/lib/vega
     script:
       - vega.min.js
+    stylesheet:
+      - vega-styles.css
   - name: vega-tooltip
     version: 1.0
     src: htmlwidgets/lib/vega-tooltip

--- a/inst/htmlwidgets/lib/datatables/datatables.css
+++ b/inst/htmlwidgets/lib/datatables/datatables.css
@@ -1182,9 +1182,9 @@ div.dts div.dts_label {
   z-index: 2;
   display: none;
 }
-div.dts div.dataTables_scrollBody {
+/* div.dts div.dataTables_scrollBody {
   background: repeating-linear-gradient(45deg, #edeeff, #edeeff 10px, white 10px, white 20px);
-}
+} */
 div.dts div.dataTables_scrollBody table {
   background-color: white;
   z-index: 2;
@@ -1197,8 +1197,8 @@ div.dts div.dataTables_length {
 
 /* CUSTOM GLIMMA CSS BELOW */
 
-th { font-size: 11px; }
-td { font-size: 10px; }
+th { font-size: 8pt; }
+td { font-size: 8pt; }
 
 table.dataTable tbody tr.stripe1 {
   background-color: #ffffff;
@@ -1223,6 +1223,10 @@ table.dataTable tbody tr.stripe2.selected {
 
 div.container {
   width: 80%;
+}
+
+div.dts div.dataTables_scrollBody {
+  background: white;
 }
 
 /* dt buttons */
@@ -1310,6 +1314,8 @@ label
 /* selected genes display  */
 .geneDisplay 
 {
+  /* todo: phase out geneDisplay due to scrolling ability */
+  display: none;
   width: 100%;
   margin-bottom: 10px;
   min-height: 20px;

--- a/inst/htmlwidgets/lib/datatables/datatables.css
+++ b/inst/htmlwidgets/lib/datatables/datatables.css
@@ -1307,7 +1307,7 @@ label
 /* search input border */
 .dataTables_wrapper .dataTables_filter input {
   border: solid 1px #d8d8d8;
-  border-radius: 2px;
+  border-radius: 4px;
   height: 23px;
 }
 

--- a/inst/htmlwidgets/lib/libMDS/styles.css
+++ b/inst/htmlwidgets/lib/libMDS/styles.css
@@ -106,25 +106,3 @@ button.saveButton:active {
 	border: 1px solid #f5c6cb;
 	border-radius: .25rem;
 }
-
-/* styling vega components */
-
-.vega-bind-name {
-	margin-right: 2px;
-	margin-bottom: 5px;
-	font-size: 12px;
-	font-family: sans-serif;
-	color: #404040;
-	display: block;
-}
-
-.vega-bind select {
-	margin-bottom: 7px;
-	margin-right: 7px;
-}
-
-select
-{
-	display: block;
-	width: 90%;
-}

--- a/inst/htmlwidgets/lib/libMDS/styles.css
+++ b/inst/htmlwidgets/lib/libMDS/styles.css
@@ -57,7 +57,7 @@ button.saveButton:active {
 	width: 100vw;
 	height: 100vh;
 	background-color: rgba(0, 0, 0, 0.5);
-	z-index: 1;
+	z-index: 3;
 }
 
 .saveModal {
@@ -68,14 +68,13 @@ button.saveButton:active {
 	background-color: #f1f1f1;
 	min-width: 160px;
 	box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
-	z-index: 1;
+	z-index: 3;
 	border-radius: 4px;
 	text-align: left;
 }
 
 .saveModal a {
     position: relative;
-    z-index: 1;
 	padding: 12px 16px;
 	text-decoration: none;
 	display: block;

--- a/inst/htmlwidgets/lib/libXY/XYSpecs.js
+++ b/inst/htmlwidgets/lib/libXY/XYSpecs.js
@@ -21,8 +21,8 @@ function createXYSpec(xyData, xyTable, width, height)
     "$schema": "https://vega.github.io/schema/vega/v5.json",
     "description": "Testing ground for GlimmaV2",
     "width": xyData.counts == -1 ? (width*0.9) : (width * 0.5),
-    "height": height * 0.35,
-    "padding": {"left": 0, "top": 0, "right": 0, "bottom": 10},
+    "height": height * 0.45,
+    "padding": {"left": 0, "top": 0, "right": 0, "bottom": 5},
     "autosize": {"type": "fit", "resize": true},
     "title": {
       "text": xyData.title

--- a/inst/htmlwidgets/lib/libXY/saveTools.js
+++ b/inst/htmlwidgets/lib/libXY/saveTools.js
@@ -1,7 +1,6 @@
 function hideDropdownsOnHoverAway() 
 {
   window.addEventListener("mouseover", (event) => {
-    console.log(event.target);
     const buttonContainer = event.target.closest(".buttonContainer");
     if (buttonContainer !== null) {
       return;

--- a/inst/htmlwidgets/lib/libXY/styles.css
+++ b/inst/htmlwidgets/lib/libXY/styles.css
@@ -32,28 +32,12 @@
 
 /* contains everything that is not a plot */
 
-.controlContainerMDS {
-	padding: 10px;
-	display: grid;
-	grid-template-columns: repeat(6, 1fr);
-	font-family: sans-serif;
-	color: #353535;
-	font-size: 9px;
-}
-
 .controlContainerXY {
 	padding: 10px;
 	display: block;
 	font-family: sans-serif;
 	color: #353535;
-	font-size: 9;
-}
-
-/* container for vega signal inputs */
-
-.vega-bindings {
-	display: grid;
-	grid-template-columns: 1fr 1fr 1fr;
+	font-size: 9pt;
 }
 
 /* custom styling for some inputs */
@@ -68,24 +52,6 @@
 
 .display-block {
 	display: block;
-}
-
-/* text for dropdown */
-
-.vega-bind-name {
-	margin-right: 2px;
-	margin-bottom: 5px;
-	font-size: 12px;
-	font-family: sans-serif;
-	color: #404040;
-	display: block;
-}
-
-/* dropdown controls */
-
-.vega-bind select {
-	margin-bottom: 7px;
-	margin-right: 7px;
 }
 
 /* input width */
@@ -209,18 +175,18 @@ button.save-button:active {
 	border: 1px solid #f5c6cb;
 }
 
-/* vega max y axis setting */
-input.max_y_axis, input.min_y_axis
+input.max_extent_input, input.min_extent_input
 {
-	margin-bottom: 5px;
-	margin-right: 10px;
-	border: solid 1px #b5b5b5;
-	border-radius: 2px;
+	width: 90%;
+	border: 1px solid #b5b5b5;
+	border-radius: 4px;
+	font-size: 9pt;
+	font-family: sans-serif;
 	display: block;
 }
 
-select
-{
-	display: block;
-	width: 90%;
+.expressionControls {
+	grid-column-start: 2;
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr;
 }

--- a/inst/htmlwidgets/lib/libXY/styles.css
+++ b/inst/htmlwidgets/lib/libXY/styles.css
@@ -187,7 +187,6 @@ input.max_extent_input, input.min_extent_input
 }
 
 .expressionControls {
-	grid-column-start: 2;
 	display: grid;
 	grid-template-columns: 1fr 1fr 1fr;
 }

--- a/inst/htmlwidgets/lib/libXY/styles.css
+++ b/inst/htmlwidgets/lib/libXY/styles.css
@@ -62,7 +62,8 @@
 /* Datatables button container styling */
 .buttonContainer {
 	display: inline-block;
-	margin: 0px 5px 0px 0px;
+	margin-right: 5px;
+	margin-bottom: 10px;
 }
 
 button.save-button {

--- a/inst/htmlwidgets/lib/libXY/styles.css
+++ b/inst/htmlwidgets/lib/libXY/styles.css
@@ -113,7 +113,7 @@ button.save-button:active {
 	background-color: #f1f1f1;
 	min-width: 160px;
 	box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
-	z-index: 1;
+	z-index: 3;
 	border-radius: 4px;
 }
 

--- a/inst/htmlwidgets/lib/vega/vega-styles.css
+++ b/inst/htmlwidgets/lib/vega/vega-styles.css
@@ -1,0 +1,14 @@
+.vega-bind-name {
+	margin-right: 2px;
+	margin-bottom: 5px;
+	font-size: 12px;
+	font-family: sans-serif;
+	color: #404040;
+	display: block;
+}
+
+.vega-bind select {
+    display: block;
+    width: 90%;
+    font-size: 9pt;
+}

--- a/inst/htmlwidgets/lib/vega/vega-styles.css
+++ b/inst/htmlwidgets/lib/vega/vega-styles.css
@@ -10,5 +10,8 @@
 .vega-bind select {
     display: block;
     width: 90%;
-    font-size: 9pt;
+	border: 1px solid #b5b5b5;
+	border-radius: 4px;
+	font-size: 10pt;
+	font-family: sans-serif;
 }

--- a/inst/htmlwidgets/lib/vega/vega-styles.css
+++ b/inst/htmlwidgets/lib/vega/vega-styles.css
@@ -1,7 +1,7 @@
 .vega-bind-name {
 	margin-right: 2px;
 	margin-bottom: 5px;
-	font-size: 12px;
+	font-size: 9pt;
 	font-family: sans-serif;
 	color: #404040;
 	display: block;


### PR DESCRIPTION
# Changelist
- canvas rendering, for significantly improved responsiveness
- `scroller` implementation for datatables, removing pagination + clutter
- CSS fixes for input elements
- Removal of scrollbar in glimmaXY plot quarto documents
- Hiding the `geneDisplay` panel, which is arguably made redundant by the scroller implementation
- Styling colourscheme element
- Adjusting dimensions of MA plot/expression plot to reduce empty space

### Current state
https://github.com/user-attachments/assets/ad534c43-a4fe-4b14-a50d-cefbb084a446

### After PR
https://github.com/user-attachments/assets/4d89ba61-c49b-4fa1-b476-40a42e3f3b89