### PR TITLE
pass ellipses to DESeq2::results

### DIFF
--- a/R/glimmaMA.R
+++ b/R/glimmaMA.R
@@ -296,7 +296,7 @@ glimmaMA.DESeqDataSet  <- function(
   ...)
 {
   transform.counts <- match.arg(transform.counts)
-  res.df <- as.data.frame(DESeq2::results(x))
+  res.df <- as.data.frame(DESeq2::results(x, ...))
   # filter out genes that have missing data
   complete_genes <- complete.cases(res.df)
   res.df <- res.df[complete_genes, ]

--- a/R/glimmaMA.R
+++ b/R/glimmaMA.R
@@ -304,7 +304,8 @@ glimmaMA.DESeqDataSet  <- function(
 
   total_genes <- length(complete_genes)
   filtered_genes <- sum(!complete_genes)
-  message(filtered_genes, " of ", total_genes, " genes were filtered out in DESeq2 tests")
+  if (filtered_genes > 0)
+    message(filtered_genes, " of ", total_genes, " genes were filtered out in DESeq2 tests")
 
   # extract status if it is not given
   if (is.null(status))


### PR DESCRIPTION
Glimma makes the best reports! 

I made a change to pass ... to results() so that a user can do more customization. E.g.:

```
g <- glimmaMA(
    dds, 
    groups=dds$condition, 
    transform.counts = "none", 
    anno=anno,
    test="Wald", 
    name="condition_KD_vs_WT", 
    independentFiltering=FALSE, 
    cooksCutoff=FALSE)
```

The last four are being passed to `results()` and provide a specific test of a contrast with no filtering or outlier flagging.