### PR TITLE
fix save data with multiple contrasts. 

### DIFF
--- a/inst/htmlwidgets/glimmaXY.js
+++ b/inst/htmlwidgets/glimmaXY.js
@@ -322,6 +322,7 @@ HTMLWidgets.widget({
                         clearData(datatable);
                         // @ts-ignore
                         const table = HTMLWidgets.dataframeToD3(selectedTable);
+                        data.xyTable = table;
                         data.xyView.data("source", table);
                         const title = data.titles[i];
                         data.xyView.signal("title", title);


### PR DESCRIPTION
This fixes issue #128

This change updates data.xyTable (used by "Save Data" to export to csv) whenever user changes contrast. Previously changing contrast only changes data.xyView (the table displayed on screen) so "Save Data" always save the default contrast.

I notice there are 2 files glimmaXY.js & glimmaXY.ts. Since htmlwidget seems to use only .js when I tested it, thats the file that I changed.